### PR TITLE
add withQueryString literal comparison; fix php dep

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ $guzzleClient = new \GuzzleHttp\Client([
 
 // Setup a request expectation
 $httpMock
-	->shouldReceiveRequest()
+    ->shouldReceiveRequest()
     ->withUrl('http://www.example.com/foo')
     ->withMethod('GET')
     ->withBodyParams([ 'foo' => 'bar' ])
@@ -125,7 +125,7 @@ The expectation setters are chainable, allowing for a fluid interface:
 
 ```php
 $httpMock
-	->shouldReceiveRequest()
+    ->shouldReceiveRequest()
     ->withUrl('http://www.example.com/foo')
     ->withMethod('POST');
 ```
@@ -139,13 +139,14 @@ Method | Notes
 ------ | ------
 `withUrl($url:string)` | URL (full absolute path)
 `withMethod($url:string)` | Http method.
-`withQuery($query:\GuzzleHttp\Query)` |
-`withQueryParams($params:array)` |
-`withContentType($contentType:string)` |
-`withJsonContentType()` |
-`withBody($stream:StreamInterface)` |
-`withBodyParams($params:array)` |
-`withJsonBodyParams($params:array)` |
+`withQuery($query:\GuzzleHttp\Query)` | Query with a Guzzle query object
+`withQueryParams($params:array)` | Query string with array 
+`withQueryString($queryString:string)` | Literal query string comparison
+`withContentType($contentType:string)` | Content Type
+`withJsonContentType()` | JSON Content Type
+`withBody($stream:StreamInterface)` | Compare request body
+`withBodyParams($params:array)` | Compare request body params
+`withJsonBodyParams($params:array)` | JSON body params
 `once()` | The request should be made a single time
 `times($callCount:number)` | The request should be made `$callCount` times.
 
@@ -156,12 +157,12 @@ By default, a request is expected to be made one time, with an Http method of 'G
 ```php
 // So this:
 $httpMock
-	->shouldReceiveRequest()
+    ->shouldReceiveRequest()
     ->withUrl('http://www.example.com/foo');
 
 // is the same as this:
 $httpMock
-	->shouldReceiveRequest()
+    ->shouldReceiveRequest()
     ->withUrl('http://www.example.com/foo')
     ->once()
     ->withMethod('GET');
@@ -174,7 +175,7 @@ In addition to specifying request expectations individually, you can also direct
 
 ```php
 $expectedRequest = new Request(
-	'PUT',
+    'PUT',
     'http://www.example.com/foo?faz=baz',
     [
 		'body'    => json_encode(['shazaam' => 'kablooey']),
@@ -193,10 +194,10 @@ All expectation methods accept either a value or a `callable` as a parameter. By
 
 ```php
 $httpMock
-	->shouldReceiveRequest()
-	->withBodyParams(function($actualParams) {
-	  return $actualParams['foo'] === 'bar';
-	});
+    ->shouldReceiveRequest()
+    ->withBodyParams(function($actualParams) {
+        return $actualParams['foo'] === 'bar';
+    });
 ```
 
 In this case, the expectation will fail if the actual request body has a `foo` params which does not equal `bar`.
@@ -250,11 +251,11 @@ You may mock a response directly using a response object:
 $response = new \GuzzleHttp\Psr7\Response(
     200,
     ['Content-Type' = 'application/json'],
-	json_encode(['foo' => 'bar' ]
+    json_encode(['foo' => 'bar' ]
 );
 
 $httpMock
-	->shouldReceiveRequest()
+    ->shouldReceiveRequest()
     ->withMethod('GET')
     ->withUrl('http://www.example.com/foo')
     ->andResponseWith($response);
@@ -315,7 +316,7 @@ In the current version of GuzzleHttpMock, any expectations which are not specifi
 
 ```php
 $httpMock
-	->shouldReceiveRequest()
+    ->shouldReceiveRequest()
     ->withUrl('http://www.example.com/foo');
 
 $guzzleClient->get('/foo', [
@@ -349,22 +350,22 @@ You can also try wrapping the offending code in a `try...catch` block, to give t
 
 ```php
 $this->httpMock
-	->shouldReceiveRequest()
+    ->shouldReceiveRequest()
     ->withXYZ()
     ->andRespondWith($aValidResponse);
 
 try {
-	$subjectUnderTest->doSomethingWhichExpectsAValidHttpResponse();
+    $subjectUnderTest->doSomethingWhichExpectsAValidHttpResponse();
 }
 catch (\Exception $ex) {
-	// uh oh, $subjectUnderTest made an unexpected request,
+    // uh oh, $subjectUnderTest made an unexpected request,
     // and now if does not have a valid response to work with!
     
     // Let's check our http mock, and see what happened
     $httpMock->verify();
     
     // If it's not a request expectation problem, throw the original error
-    $throw ex;
+    throw $ex;
 }
 ```
 

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
   ],
   "minimum-stability": "dev",
   "require": {
-    "php": ">=5.3.3",
+    "php": ">=5.6.0",
     "guzzlehttp/guzzle": "^6.0"
   },
   "conflict": {

--- a/composer.lock
+++ b/composer.lock
@@ -1,10 +1,10 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "875b1067e7dc078cb5226a2fe8da7473",
+    "content-hash": "1ae3ad8125ec68a6b8465f43b51c1e6a",
     "packages": [
         {
             "name": "guzzlehttp/guzzle",
@@ -120,7 +120,7 @@
             "keywords": [
                 "promise"
             ],
-            "time": "2017-05-20 23:14:18"
+            "time": "2017-05-20T23:14:18+00:00"
         },
         {
             "name": "guzzlehttp/psr7",
@@ -185,7 +185,7 @@
                 "uri",
                 "url"
             ],
-            "time": "2017-07-17 09:11:21"
+            "time": "2017-07-17T09:11:21+00:00"
         },
         {
             "name": "psr/http-message",
@@ -235,7 +235,7 @@
                 "request",
                 "response"
             ],
-            "time": "2016-08-06 14:39:51"
+            "time": "2016-08-06T14:39:51+00:00"
         }
     ],
     "packages-dev": [],
@@ -245,7 +245,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=5.3.3"
+        "php": ">=5.6.0"
     },
     "platform-dev": []
 }

--- a/test/GuzzleHttpMockTest/MockTest.php
+++ b/test/GuzzleHttpMockTest/MockTest.php
@@ -339,6 +339,21 @@ class MockTest extends \PHPUnit_Framework_TestCase {
         $this->httpMock->verify();
     }
 
+	/** @test */
+    public function shouldCompareQueryStringLiterally() {
+		$this->httpMock
+			->shouldReceiveRequest()
+			->withMethod('GET')
+			->withUrl('http://www.example.com/foo')
+			->withQueryString('param1=value1&param2=%20spaces')
+			->andRespondWithJson([ 'bar' => 'foo']);
+
+		$response1 = $this->guzzleClient
+			->get('http://www.example.com/foo?param1=value1&param2=%20spaces');
+
+		$this->assertEquals([ 'bar' => 'foo'], json_decode((string)$response1->getBody(), true));
+	}
+
 	/**
 	 * @expectedException \Aeris\GuzzleHttpMock\Exception\UnexpectedHttpRequestException
 	 * @test
@@ -498,7 +513,7 @@ class MockTest extends \PHPUnit_Framework_TestCase {
 				]
 			]);
 
-		
+
 		$this->httpMock->verify();
 	}
 
@@ -556,8 +571,8 @@ class MockTest extends \PHPUnit_Framework_TestCase {
 	}
 
 	/**
-	 * @expectedException \Aeris\GuzzleHttpMock\Exception\UnexpectedHttpRequestException 
-	 * @test 
+	 * @expectedException \Aeris\GuzzleHttpMock\Exception\UnexpectedHttpRequestException
+	 * @test
 	 */
 	public function body_customLogic_notMatch_shouldFail() {
 		$this->httpMock


### PR DESCRIPTION
Hi guys

I added some functionality we need in a test suite of ours: We needed to test if our app correctly encodes certain values (special characters) when it sends the request.

The current implementation of `withQueryParams()` does not allow for a literal and exact string comparison as the call there of `parse_str()` decodes special characters.

So I added the function, added a simple test and updated the docs.

I also corrected the minimal php version in `composer.json` as the source code includes stuff that is not supported in the stated dependency of php `>=5.3.3`.
Specific examples are [here](https://github.com/systemhaus/GuzzleHttpMock/blob/2.0/src/Expectation/RequestExpectation.php#L15) (this requires php 5.6) or [here](https://github.com/systemhaus/GuzzleHttpMock/blob/2.0/src/Expectation/RequestExpectation.php#L64) (short array syntax needs php 5.4).

Also in the class I edited and in README.md there is a bit a mess between spaces and tabs. So i tried to fix it to tabs in those places (even if I'm a "spaces for tabs guy") as it seems it's mostly tabs. My IDE forced some corrections there so each file is consistent in itself.
